### PR TITLE
Returns and raises error messages

### DIFF
--- a/lib/fumanchu.ex
+++ b/lib/fumanchu.ex
@@ -1,7 +1,7 @@
 defmodule FuManchu do
   alias FuManchu.Compiler
 
-  def render(source, context \\ %{}, partials \\ %{}) do
-    Compiler.compile(source).(%{context: context, partials: partials})
+  def render!(source, context \\ %{}, partials \\ %{}) do
+    Compiler.compile!(source).(%{context: context, partials: partials})
   end
 end

--- a/lib/fumanchu/compiler.ex
+++ b/lib/fumanchu/compiler.ex
@@ -4,10 +4,47 @@ defmodule FuManchu.Compiler do
   alias FuManchu.Generator
 
   def compile(source) do
-    {:ok, tokens} = Lexer.scan(source)
-    {:ok, ast}    = Parser.parse(tokens)
-    quoted_fun    = Generator.generate(ast)
-    {fun, []}     = Code.eval_quoted(quoted_fun)
+    source
+    |> scan
+    |> parse
+    |> generate
+    |> eval
+    |> check_fun
+  end
+
+  defp scan(source) do
+    Lexer.scan(source)
+  end
+
+  defp parse({:ok, tokens}) do
+    Parser.parse(tokens)
+  end
+
+  defp parse({:error, error}) do
+    raise error
+  end
+
+  defp generate({:ok, ast}) do
+    Generator.generate(ast)
+  end
+
+  defp generate({:error, error}) do
+    raise error
+  end
+
+  defp eval({:ok, quoted_fun}) do
+    Code.eval_quoted(quoted_fun)
+  end
+
+  defp eval({:error, error}) do
+    raise error
+  end
+
+  defp check_fun({fun, []}) do
     fun
+  end
+
+  defp check_fun(_) do
+    raise "We didn't get a function like we expected; there's probably a bug in the generator."
   end
 end

--- a/lib/fumanchu/compiler.ex
+++ b/lib/fumanchu/compiler.ex
@@ -40,7 +40,7 @@ defmodule FuManchu.Compiler do
     raise error
   end
 
-  defp check_fun({fun, []}) do
+  defp check_fun({fun, []}) when is_function(fun, 1) do
     fun
   end
 

--- a/lib/fumanchu/compiler.ex
+++ b/lib/fumanchu/compiler.ex
@@ -3,7 +3,7 @@ defmodule FuManchu.Compiler do
   alias FuManchu.Parser
   alias FuManchu.Generator
 
-  def compile(source) do
+  def compile!(source) do
     source
     |> scan
     |> parse

--- a/lib/fumanchu/generator.ex
+++ b/lib/fumanchu/generator.ex
@@ -1,8 +1,9 @@
 defmodule FuManchu.Generator do
+  # TODO: Handle errors while generating quoted fun
   def generate(children) when is_list(children) do
     elements = Enum.map(children, &generate/1)
 
-    quote do
+    quoted_fun = quote do
       fn %{context: context, partials: partials} ->
         import FuManchu.Util
 
@@ -11,6 +12,8 @@ defmodule FuManchu.Generator do
         end.(stringify_keys(context))
       end
     end
+
+    {:ok, quoted_fun}
   end
 
   def generate({type, text, _line})

--- a/lib/fumanchu/generator.ex
+++ b/lib/fumanchu/generator.ex
@@ -115,7 +115,7 @@ defmodule FuManchu.Generator do
         |> Enum.map(&(unquote(indent) <> &1))
         |> Enum.join("\n")
 
-        FuManchu.render(source, context, partials)
+        FuManchu.render!(source, context, partials)
       end.(context)
     end
   end

--- a/lib/fumanchu/generator/ast_node_unrecognized_error.ex
+++ b/lib/fumanchu/generator/ast_node_unrecognized_error.ex
@@ -1,0 +1,8 @@
+defmodule FuManchu.Generator.ASTNodeUnrecognizedError do
+  defexception [:message]
+
+  def exception(%{node_name: node_name, line: line}) do
+    message = ~s[template:#{line}: unrecognized ast node: #{inspect node_name}]
+    %__MODULE__{message: message}
+  end
+end

--- a/lib/fumanchu/lexer.ex
+++ b/lib/fumanchu/lexer.ex
@@ -1,12 +1,35 @@
+defmodule FuManchu.Lexer.TokenMissingError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{parsed_line: parsed_line, terminator: terminator, starting: starting, starting_line: starting_line}) do
+    message = ~s[template:#{parsed_line}: missing terminator: #{inspect terminator} (for #{inspect starting} starting at line #{starting_line})]
+    %FuManchu.Lexer.TokenMissingError{message: message}
+  end
+end
+
+defmodule FuManchu.Lexer.TokenUnexpectedError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{parsed_line: parsed_line, token: token}) do
+    message = ~s[template:#{parsed_line}: unexpected token: #{inspect token}]
+    %FuManchu.Lexer.TokenUnexpectedError{message: message}
+  end
+end
+
 defmodule FuManchu.Lexer do
+  alias FuManchu.Lexer.TokenMissingError
+  alias FuManchu.Lexer.TokenUnexpectedError
+
   def scan(bin) when is_binary(bin) do
     scan(String.to_char_list(bin))
   end
 
   def scan(char_list) do
     case scan(char_list, [], [], 1) do
-      :error ->
-        :error
+      {:error, error} ->
+        {:error, error}
       tokens ->
         {:ok, tokens}
     end
@@ -14,14 +37,30 @@ defmodule FuManchu.Lexer do
 
   defp scan('{{{' ++ t, buffer, acc, line) do
     acc = append_text(buffer, acc, line)
-    {{:unescaped_variable, key, next_line}, t} = scan_tag(t, [], line)
-    scan(t, [], [{:unescaped_variable, key, line}|acc], next_line)
+
+    case scan_tag(t, [], line) do
+      {:error, %{rest: []}=opts} ->
+        opts = Map.merge(opts, %{terminator: "}}}", starting: "{{{", starting_line: line})
+        {:error, TokenMissingError.exception(opts)}
+      {:error, opts} ->
+        {:error, TokenUnexpectedError.exception(opts)}
+      {{:unescaped_variable, key, next_line}, t} ->
+        scan(t, [], [{:unescaped_variable, key, line}|acc], next_line)
+    end
   end
 
   defp scan('{{' ++ t, buffer, acc, line) do
     acc = append_text(buffer, acc, line)
-    {{tag, key, next_line}, t} = scan_tag(t, [], line)
-    scan(t, [], [{tag, key, line}|acc], next_line)
+
+    case scan_tag(t, [], line) do
+      {:error, %{rest: []}=opts} ->
+        opts = Map.merge(opts, %{terminator: "}}", starting: "{{", starting_line: line})
+        {:error, TokenMissingError.exception(opts)}
+      {:error, opts} ->
+        {:error, TokenUnexpectedError.exception(opts)}
+      {{tag, key, next_line}, t} ->
+        scan(t, [], [{tag, key, line}|acc], next_line)
+    end
   end
 
   defp scan('\r\n' ++ t, buffer, acc, line) do
@@ -73,6 +112,14 @@ defmodule FuManchu.Lexer do
     {{type, key, line}, t}
   end
 
+  defp scan_tag('{{{' ++ t, _acc, line) do
+    {:error, %{parsed_line: line, token: "{{{", rest: t}}
+  end
+
+  defp scan_tag('{{' ++ t, _acc, line) do
+    {:error, %{parsed_line: line, token: "{{", rest: t}}
+  end
+
   defp scan_tag('\r\n' ++ t, acc, line) do
     scan_tag(t, acc, line + 1)
   end
@@ -83,6 +130,10 @@ defmodule FuManchu.Lexer do
 
   defp scan_tag([h|t], acc, line) do
     scan_tag(t, [h|acc], line)
+  end
+
+  defp scan_tag([], _acc, line) do
+    {:error, %{parsed_line: line, rest: []}}
   end
 
   defp append_text([], acc, _line) do

--- a/lib/fumanchu/lexer.ex
+++ b/lib/fumanchu/lexer.ex
@@ -1,23 +1,3 @@
-defmodule FuManchu.Lexer.TokenMissingError do
-  defexception [:message]
-
-  # TODO: Support passing in the filename of the template
-  def exception(%{parsed_line: parsed_line, terminator: terminator, starting: starting, starting_line: starting_line}) do
-    message = ~s[template:#{parsed_line}: missing terminator: #{inspect terminator} (for #{inspect starting} starting at line #{starting_line})]
-    %FuManchu.Lexer.TokenMissingError{message: message}
-  end
-end
-
-defmodule FuManchu.Lexer.TokenUnexpectedError do
-  defexception [:message]
-
-  # TODO: Support passing in the filename of the template
-  def exception(%{parsed_line: parsed_line, token: token}) do
-    message = ~s[template:#{parsed_line}: unexpected token: #{inspect token}]
-    %FuManchu.Lexer.TokenUnexpectedError{message: message}
-  end
-end
-
 defmodule FuManchu.Lexer do
   alias FuManchu.Lexer.TokenMissingError
   alias FuManchu.Lexer.TokenUnexpectedError

--- a/lib/fumanchu/lexer/token_missing_error.ex
+++ b/lib/fumanchu/lexer/token_missing_error.ex
@@ -1,0 +1,9 @@
+defmodule FuManchu.Lexer.TokenMissingError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{parsed_line: parsed_line, terminator: terminator, starting: starting, starting_line: starting_line}) do
+    message = ~s[template:#{parsed_line}: missing terminator: #{inspect terminator} (for #{inspect starting} starting at line #{starting_line})]
+    %__MODULE__{message: message}
+  end
+end

--- a/lib/fumanchu/lexer/token_unexpected_error.ex
+++ b/lib/fumanchu/lexer/token_unexpected_error.ex
@@ -1,0 +1,9 @@
+defmodule FuManchu.Lexer.TokenUnexpectedError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{parsed_line: parsed_line, token: token}) do
+    message = ~s[template:#{parsed_line}: unexpected token: #{inspect token}]
+    %__MODULE__{message: message}
+  end
+end

--- a/lib/fumanchu/parser.ex
+++ b/lib/fumanchu/parser.ex
@@ -1,23 +1,3 @@
-defmodule FuManchu.Parser.TokenMissingError do
-  defexception [:message]
-
-  # TODO: Support passing in the filename of the template
-  def exception(%{parsed_line: parsed_line, token_name: token_name, token: token, starting: starting, starting_line: starting_line}) do
-    message = ~s[template:#{parsed_line}: missing #{token_name}: #{inspect token} (for #{inspect starting} starting at line #{starting_line})]
-    %FuManchu.Parser.TokenMissingError{message: message}
-  end
-end
-
-defmodule FuManchu.Parser.TokenUnrecognizedError do
-  defexception [:message]
-
-  # TODO: Support passing in the filename of the template
-  def exception(%{line: line, token: token}) do
-    message = ~s[template:#{line}: unrecognized token: #{inspect token}]
-    %FuManchu.Parser.TokenUnrecognizedError{message: message}
-  end
-end
-
 defmodule FuManchu.Parser do
   alias FuManchu.Parser.TokenMissingError
   alias FuManchu.Parser.TokenUnrecognizedError

--- a/lib/fumanchu/parser.ex
+++ b/lib/fumanchu/parser.ex
@@ -1,12 +1,36 @@
+defmodule FuManchu.Parser.TokenMissingError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{line: line, token_name: token_name, token: token, starting: starting}) do
+    message = ~s[template:#{line}: missing #{token_name}: #{inspect token} (for #{inspect starting} starting at line #{line})]
+    %FuManchu.Parser.TokenMissingError{message: message}
+  end
+end
+
+defmodule FuManchu.Parser.TokenUnrecognizedError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{line: line, token: token}) do
+    message = ~s[template:#{line}: unrecognized token: #{inspect token}]
+    %FuManchu.Parser.TokenUnrecognizedError{message: message}
+  end
+end
+
 defmodule FuManchu.Parser do
+  alias FuManchu.Parser.TokenMissingError
+  alias FuManchu.Parser.TokenUnrecognizedError
+
   @collapsible_tags [:section_begin, :inverted_section_begin, :section_end, :comment, :partial]
+  @passthrough_tokens [:variable, :unescaped_variable, :partial, :text, :newline, :whitespace]
   @marker_begin {:newline, "\n", 0}
   @marker_end   {:newline, "\n", -1}
 
   def parse(tokens) do
     case parse([@marker_begin] ++ tokens ++ [@marker_end], []) do
-      :error ->
-        :error
+      {:error, error} ->
+        {:error, error}
       ast ->
         {:ok, ast}
     end
@@ -31,13 +55,23 @@ defmodule FuManchu.Parser do
   end
 
   defp parse([{:section_begin, name, line}|t], [h|_]=acc) do
-    {{:section, ^name, _line, [^h|children]}, t} = parse([h|t], [])
-    parse(t, [{:section, name, line, children}|acc])
+    case parse([h|t], []) do
+      {{:section, ^name, _line, [^h|children]}, t} ->
+        parse(t, [{:section, name, line, children}|acc])
+      _ ->
+        opts = %{token_name: "section end", token: "{{/#{name}}}", starting: "{{##{name}}}", line: line}
+        {:error, TokenMissingError.exception(opts)}
+    end
   end
 
   defp parse([{:inverted_section_begin, name, line}|t], [h|_]=acc) do
-    {{:section, ^name, _line, [^h|children]}, t} = parse([h|t], [])
-    parse(t, [{:inverted_section, name, line, children}|acc])
+    case parse([h|t], []) do
+      {{:section, ^name, _line, [^h|children]}, t} ->
+        parse(t, [{:inverted_section, name, line, children}|acc])
+      _ ->
+        opts = %{token_name: "section end", token: "{{/#{name}}}", starting: "{{^#{name}}}", line: line}
+        {:error, TokenMissingError.exception(opts)}
+    end
   end
 
   defp parse([{:section_end, name, line}|t], acc) do
@@ -48,8 +82,13 @@ defmodule FuManchu.Parser do
     parse(t, acc)
   end
 
-  defp parse([h|t], acc) do
+  defp parse([{token, _, _}=h|t], acc)
+      when token in @passthrough_tokens do
     parse(t, [h|acc])
+  end
+
+  defp parse([{token, _, line}|_t], _acc) do
+    {:error, TokenUnrecognizedError.exception(%{token: token, line: line})}
   end
 
   defp parse([], [@marker_end|acc]) do
@@ -57,7 +96,11 @@ defmodule FuManchu.Parser do
   end
 
   defp parse([], acc) do
-    [@marker_begin|acc] = Enum.reverse(acc)
-    acc
+    case Enum.reverse(acc) do
+      [@marker_begin|acc] ->
+        acc
+      acc ->
+        acc
+    end
   end
 end

--- a/lib/fumanchu/parser/token_missing_error.ex
+++ b/lib/fumanchu/parser/token_missing_error.ex
@@ -1,0 +1,9 @@
+defmodule FuManchu.Parser.TokenMissingError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{parsed_line: parsed_line, token_name: token_name, token: token, starting: starting, starting_line: starting_line}) do
+    message = ~s[template:#{parsed_line}: missing #{token_name}: #{inspect token} (for #{inspect starting} starting at line #{starting_line})]
+    %__MODULE__{message: message}
+  end
+end

--- a/lib/fumanchu/parser/token_unrecognized_error.ex
+++ b/lib/fumanchu/parser/token_unrecognized_error.ex
@@ -1,0 +1,9 @@
+defmodule FuManchu.Parser.TokenUnrecognizedError do
+  defexception [:message]
+
+  # TODO: Support passing in the filename of the template
+  def exception(%{line: line, token: token}) do
+    message = ~s[template:#{line}: unrecognized token: #{inspect token}]
+    %__MODULE__{message: message}
+  end
+end

--- a/test/fumanchu/generator_test.exs
+++ b/test/fumanchu/generator_test.exs
@@ -3,19 +3,19 @@ defmodule FuManchu.GeneratorTest do
   alias FuManchu.Generator
 
   test "generating text" do
-    quoted_fun = Generator.generate([{:text, "Hello World!", 1}])
+    {:ok, quoted_fun} = Generator.generate([{:text, "Hello World!", 1}])
     {fun, []} = Code.eval_quoted(quoted_fun)
     assert fun.(%{context: %{}, partials: %{}}) == "Hello World!"
   end
 
   test "generating a variable" do
-    quoted_fun = Generator.generate([{:text, "Hello ", 1}, {:variable, ["planet"], 1}])
+    {:ok, quoted_fun} = Generator.generate([{:text, "Hello ", 1}, {:variable, ["planet"], 1}])
     {fun, []} = Code.eval_quoted(quoted_fun)
     assert fun.(%{context: %{planet: "World!"}, partials: %{}}) == "Hello World!"
   end
 
   test "generating a section containing a variable" do
-    quoted_fun = Generator.generate([{:section, ["repo"], 3, [
+    {:ok, quoted_fun} = Generator.generate([{:section, ["repo"], 3, [
                                        {:text, "\n  ", 1},
                                        {:text, "<b>", 2},
                                        {:section, ["name"], 2, [
@@ -29,7 +29,7 @@ defmodule FuManchu.GeneratorTest do
   end
 
   test "generating a section used for iteration" do
-    quoted_fun = Generator.generate([{:section, ["commands"], 1, [
+    {:ok, quoted_fun} = Generator.generate([{:section, ["commands"], 1, [
                                        {:variable, ".", 1},
                                        {:text, "\n", 1}]}])
     {fun, []} = Code.eval_quoted(quoted_fun)
@@ -40,7 +40,7 @@ defmodule FuManchu.GeneratorTest do
   end
 
   test "generating a section used for iteration by key" do
-    quoted_fun = Generator.generate([{:text, "\"", 1},
+    {:ok, quoted_fun} = Generator.generate([{:text, "\"", 1},
                                      {:section, ["list"], 1, [
                                        {:variable, ["item"], 1}]},
                                      {:text, "\"", 1}])

--- a/test/fumanchu/generator_test.exs
+++ b/test/fumanchu/generator_test.exs
@@ -9,16 +9,16 @@ defmodule FuManchu.GeneratorTest do
   end
 
   test "generating a variable" do
-    {:ok, quoted_fun} = Generator.generate([{:text, "Hello ", 1}, {:variable, ["planet"], 1}])
+    {:ok, quoted_fun} = Generator.generate([{:text, "Hello ", 1}, {:variable, "planet", 1}])
     {fun, []} = Code.eval_quoted(quoted_fun)
     assert fun.(%{context: %{planet: "World!"}, partials: %{}}) == "Hello World!"
   end
 
   test "generating a section containing a variable" do
-    {:ok, quoted_fun} = Generator.generate([{:section, ["repo"], 3, [
+    {:ok, quoted_fun} = Generator.generate([{:section, "repo", 3, [
                                        {:text, "\n  ", 1},
                                        {:text, "<b>", 2},
-                                       {:section, ["name"], 2, [
+                                       {:section, "name", 2, [
                                          {:text, "fumanchu", 2}]},
                                        {:text, "</b>\n", 2}]},
                                      {:text, "\n", 3}])
@@ -29,7 +29,7 @@ defmodule FuManchu.GeneratorTest do
   end
 
   test "generating a section used for iteration" do
-    {:ok, quoted_fun} = Generator.generate([{:section, ["commands"], 1, [
+    {:ok, quoted_fun} = Generator.generate([{:section, "commands", 1, [
                                        {:variable, ".", 1},
                                        {:text, "\n", 1}]}])
     {fun, []} = Code.eval_quoted(quoted_fun)
@@ -41,10 +41,21 @@ defmodule FuManchu.GeneratorTest do
 
   test "generating a section used for iteration by key" do
     {:ok, quoted_fun} = Generator.generate([{:text, "\"", 1},
-                                     {:section, ["list"], 1, [
-                                       {:variable, ["item"], 1}]},
+                                     {:section, "list", 1, [
+                                       {:variable, "item", 1}]},
                                      {:text, "\"", 1}])
     {fun, []} = Code.eval_quoted(quoted_fun)
     assert fun.(%{context: %{list: [%{item: 1}, %{item: 2}, %{item: 3}]}, partials: %{}}) == "\"123\""
+  end
+
+  test "generating code for an unknown ast" do
+    ast = [{:text, "What's for dinner?", 1},
+           {:newline, "\n", 1},
+           {:section, "is_lasagna", 2, [
+             {:wut, "wut", 2}]}]
+
+    error = %Generator.ASTNodeUnrecognizedError{message: ~s[template:2: unrecognized ast node: :wut]}
+
+    assert Generator.generate(ast) == {:error, error}
   end
 end

--- a/test/fumanchu/lexer_test.exs
+++ b/test/fumanchu/lexer_test.exs
@@ -74,4 +74,27 @@ defmodule FuManchu.LexerTest do
 
     assert Lexer.scan(template) == {:ok, tokens}
   end
+
+  test "raises error for missing tag end" do
+    template = """
+    What's for dinner? {{!
+    Please say lasagna.
+    """
+
+    error = %Lexer.TokenMissingError{message: ~s[template:3: missing terminator: "}}" (for "{{" starting at line 1)]}
+
+    assert Lexer.scan(template) == {:error, error}
+  end
+
+  test "raises error for unexpected tag begin" do
+    template = """
+    What's for dinner? {{!
+    Please say lasagna.
+    {{
+    """
+
+    error = %Lexer.TokenUnexpectedError{message: ~s[template:3: unexpected token: "{{"]}
+
+    assert Lexer.scan(template) == {:error, error}
+  end
 end

--- a/test/fumanchu/lexer_test.exs
+++ b/test/fumanchu/lexer_test.exs
@@ -1,5 +1,6 @@
 defmodule FuManchu.LexerTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
   alias FuManchu.Lexer
 
   test "scans a typical template" do
@@ -96,5 +97,27 @@ defmodule FuManchu.LexerTest do
     error = %Lexer.TokenUnexpectedError{message: ~s[template:3: unexpected token: "{{"]}
 
     assert Lexer.scan(template) == {:error, error}
+  end
+
+  test "raises error for unexpected escaped tag begin" do
+    template = """
+    What's for dinner? {{{food}}
+    """
+
+    error = %Lexer.TokenUnexpectedError{message: ~s[template:1: unexpected token: "}}"]}
+
+    assert Lexer.scan(template) == {:error, error}
+  end
+
+  test "warns for mismatched tag end" do
+    template = """
+    What's for dinner? {{food}}}
+    """
+
+    warning = capture_log(fn ->
+      Lexer.scan(template)
+    end)
+
+    assert warning =~ ~s[template:1: tag end mismatched: "}}}"]
   end
 end

--- a/test/fumanchu/parser_test.exs
+++ b/test/fumanchu/parser_test.exs
@@ -5,35 +5,38 @@ defmodule FuManchu.ParserTest do
   test "parses tokens from a typical template" do
     tokens = [{:text, "Hello ", 1},
               {:variable, "name", 1},
-              {:text, "\n", 1},
+              {:newline, "\n", 1},
 
               {:text, "You have just won ", 2},
               {:variable, "value", 2},
-              {:text, " dollars!\n", 2},
+              {:text, " dollars!", 2},
+              {:newline, "\n", 2},
+
 
               {:section_begin, "in_ca", 3},
-              {:text, "\n", 3},
+              {:newline, "\n", 3},
 
               {:text, "Well, ", 4},
               {:variable, "taxed_value", 4},
-              {:text, " dollars, after taxes.\n", 4},
+              {:text, " dollars, after taxes.", 4},
+              {:newline, "\n", 4},
 
               {:section_end, "in_ca", 5},
-              {:text, "\n", 5}]
+              {:newline, "\n", 5}]
 
     ast = [{:text, "Hello ", 1},
            {:variable, "name", 1},
-           {:text, "\n", 1},
+           {:newline, "\n", 1},
            {:text, "You have just won ", 2},
            {:variable, "value", 2},
-           {:text, " dollars!\n", 2},
+           {:text, " dollars!", 2},
+           {:newline, "\n", 2},
            {:section, "in_ca", 3, [
-             {:text, "\n", 3},
              {:text, "Well, ", 4},
              {:variable, "taxed_value", 4},
-             {:text, " dollars, after taxes.\n", 4}
-           ]},
-           {:text, "\n", 5}]
+             {:text, " dollars, after taxes.", 4},
+             {:newline, "\n", 4},
+           ]}]
 
     assert Parser.parse(tokens) == {:ok, ast}
   end
@@ -41,20 +44,22 @@ defmodule FuManchu.ParserTest do
   test "raises error for missing section end" do
     tokens = [{:text, "Hello ", 1},
               {:variable, "name", 1},
-              {:text, "\n", 1},
+              {:newline, "\n", 1},
 
               {:text, "You have just won ", 2},
               {:variable, "value", 2},
-              {:text, " dollars!\n", 2},
+              {:text, " dollars!", 2},
+              {:newline, "\n", 2},
 
               {:section_begin, "in_ca", 3},
-              {:text, "\n", 3},
+              {:newline, "\n", 3},
 
               {:text, "Well, ", 4},
               {:variable, "taxed_value", 4},
-              {:text, " dollars, after taxes.\n", 4},
+              {:text, " dollars, after taxes.", 4},
+              {:newline, "\n", 4},
 
-              {:text, "\n", 5}]
+              {:newline, "\n", 5}]
 
     error = %Parser.TokenMissingError{message: ~s[template:5: missing section end: "{{/in_ca}}" (for "{{#in_ca}}" starting at line 3)]}
 
@@ -64,11 +69,11 @@ defmodule FuManchu.ParserTest do
   test "raises error for unrecognized token" do
     tokens = [{:text, "Hello ", 1},
               {:variable, "name", 1},
-              {:text, "\n", 1},
+              {:newline, "\n", 1},
 
               {:wut, "wut", 2},
 
-              {:text, "\n", 3}]
+              {:newline, "\n", 3}]
 
     error = %Parser.TokenUnrecognizedError{message: ~s[template:2: unrecognized token: :wut]}
 

--- a/test/fumanchu/parser_test.exs
+++ b/test/fumanchu/parser_test.exs
@@ -56,7 +56,7 @@ defmodule FuManchu.ParserTest do
 
               {:text, "\n", 5}]
 
-    error = %Parser.TokenMissingError{message: ~s[template:3: missing section end: "{{/in_ca}}" (for "{{#in_ca}}" starting at line 3)]}
+    error = %Parser.TokenMissingError{message: ~s[template:5: missing section end: "{{/in_ca}}" (for "{{#in_ca}}" starting at line 3)]}
 
     assert Parser.parse(tokens) == {:error, error}
   end

--- a/test/fumanchu/parser_test.exs
+++ b/test/fumanchu/parser_test.exs
@@ -37,4 +37,41 @@ defmodule FuManchu.ParserTest do
 
     assert Parser.parse(tokens) == {:ok, ast}
   end
+
+  test "raises error for missing section end" do
+    tokens = [{:text, "Hello ", 1},
+              {:variable, "name", 1},
+              {:text, "\n", 1},
+
+              {:text, "You have just won ", 2},
+              {:variable, "value", 2},
+              {:text, " dollars!\n", 2},
+
+              {:section_begin, "in_ca", 3},
+              {:text, "\n", 3},
+
+              {:text, "Well, ", 4},
+              {:variable, "taxed_value", 4},
+              {:text, " dollars, after taxes.\n", 4},
+
+              {:text, "\n", 5}]
+
+    error = %Parser.TokenMissingError{message: ~s[template:3: missing section end: "{{/in_ca}}" (for "{{#in_ca}}" starting at line 3)]}
+
+    assert Parser.parse(tokens) == {:error, error}
+  end
+
+  test "raises error for unrecognized token" do
+    tokens = [{:text, "Hello ", 1},
+              {:variable, "name", 1},
+              {:text, "\n", 1},
+
+              {:wut, "wut", 2},
+
+              {:text, "\n", 3}]
+
+    error = %Parser.TokenUnrecognizedError{message: ~s[template:2: unrecognized token: :wut]}
+
+    assert Parser.parse(tokens) == {:error, error}
+  end
 end

--- a/test/fumanchu/spec_test.exs
+++ b/test/fumanchu/spec_test.exs
@@ -36,7 +36,7 @@ defmodule FuManchu.SpecTest do
       @tag optional: optional
 
       test "#{name} - #{desc} - #{index}" do
-        actual = FuManchu.render(unquote(template), unquote(data), unquote(partials))
+        actual = FuManchu.render!(unquote(template), unquote(data), unquote(partials))
         assert actual == unquote(expected)
       end
     end

--- a/test/fumanchu_test.exs
+++ b/test/fumanchu_test.exs
@@ -1,5 +1,7 @@
 defmodule FuManchuTest do
   use ExUnit.Case, async: true
+  alias FuManchu.Lexer.TokenUnexpectedError
+
   doctest FuManchu
 
   test "render a template with context" do
@@ -29,5 +31,21 @@ defmodule FuManchuTest do
 
     Try calling `operable:help COMMAND` to find out more.
     """
+  end
+
+  test "raises an error if the template couldn't be compiled" do
+    template = """
+    I know about these commands:
+
+    {{#commands}}
+      * {{.}
+    {{/commands}}
+
+    Try calling `operable:help COMMAND` to find out more.
+    """
+
+    assert_raise TokenUnexpectedError, ~s[template:5: unexpected token: "{{"], fn ->
+      FuManchu.render(template, %{commands: ["operable:help", "operable:echo"]})
+    end
   end
 end

--- a/test/fumanchu_test.exs
+++ b/test/fumanchu_test.exs
@@ -5,7 +5,7 @@ defmodule FuManchuTest do
   doctest FuManchu
 
   test "render a template with context" do
-    result = FuManchu.render("Hello {{planet}}", %{planet: "World!"})
+    result = FuManchu.render!("Hello {{planet}}", %{planet: "World!"})
 
     assert result == "Hello World!"
   end
@@ -21,7 +21,7 @@ defmodule FuManchuTest do
     Try calling `operable:help COMMAND` to find out more.
     """
 
-    result = FuManchu.render(template, %{commands: ["operable:help", "operable:echo"]})
+    result = FuManchu.render!(template, %{commands: ["operable:help", "operable:echo"]})
 
     assert result == """
     I know about these commands:
@@ -45,7 +45,7 @@ defmodule FuManchuTest do
     """
 
     assert_raise TokenUnexpectedError, ~s[template:5: unexpected token: "{{"], fn ->
-      FuManchu.render(template, %{commands: ["operable:help", "operable:echo"]})
+      FuManchu.render!(template, %{commands: ["operable:help", "operable:echo"]})
     end
   end
 end


### PR DESCRIPTION
Returns error messages and emit warnings (well just 1 kind) during lexing, parsing and generating. Errors are raised if returned to the compiler.

Here's what happens for mismatched tags:

```
iex(1)> FuManchu.render("{{greets}}}", %{"greets" => "hello"}) 

14:07:49.468 [warn]  template:1: tag end mismatched: "}}}"
"hello}"
```
