### PR TITLE
Allow nil as an input for templates

### DIFF
--- a/lib/fumanchu/util.ex
+++ b/lib/fumanchu/util.ex
@@ -1,4 +1,7 @@
 defmodule FuManchu.Util do
+  def stringify_keys(nil) do
+    stringify_value(nil)
+  end
   def stringify_keys(map) when is_map(map) do
     for {k, v} <- map, into: %{},
       do: {stringify_key(k), stringify_value(v)}


### PR DESCRIPTION
Currently, if a nil context is received from the commands, there is a failure in fumanchu that it does not know how to handle a nil result. This should allow a command to use an 'empty response' template if the result of the command is `nil`
