### PR TITLE
Support function partials, rather than just strings

### DIFF
--- a/lib/fumanchu/generator.ex
+++ b/lib/fumanchu/generator.ex
@@ -146,7 +146,7 @@ defmodule FuManchu.Generator do
           partial when is_function(partial) ->
             # This case is currently undocumented and considered experimental
             # as it is not defined in the spec.
-            partial.(context) <> "\n"
+            partial.(context)
         end
       end.(context)
     end

--- a/lib/fumanchu/generator.ex
+++ b/lib/fumanchu/generator.ex
@@ -134,13 +134,20 @@ defmodule FuManchu.Generator do
   def generate({:partial, name, _line, _col, indent}) do
     quote do
       fn context ->
-        source = partials
-        |> Map.get(unquote(name), "")
-        |> String.split("\n")
-        |> Enum.map(&(unquote(indent) <> &1))
-        |> Enum.join("\n")
+        partial = Map.get(partials, unquote(name), "")
 
-        FuManchu.render!(source, context, partials)
+        case partial do
+          partial when is_binary(partial) ->
+            partial
+            |> String.split("\n")
+            |> Enum.map(&(unquote(indent) <> &1))
+            |> Enum.join("\n")
+            |> FuManchu.render!(context, partials)
+          partial when is_function(partial) ->
+            # This case is currently undocumented and considered experimental
+            # as it is not defined in the spec.
+            partial.(context) <> "\n"
+        end
       end.(context)
     end
   end

--- a/lib/fumanchu/util.ex
+++ b/lib/fumanchu/util.ex
@@ -5,6 +5,8 @@ defmodule FuManchu.Util do
   end
   def stringify_keys(list) when is_list(list),
     do: stringify_value(list)
+  def stringify_keys(scalar),
+    do: scalar
 
   defp stringify_key(atom) when is_atom(atom),
     do: Atom.to_string(atom)

--- a/test/fumanchu/generator_test.exs
+++ b/test/fumanchu/generator_test.exs
@@ -63,7 +63,7 @@ defmodule FuManchu.GeneratorTest do
   test "generating a function partial" do
     {:ok, quoted_fun} = Generator.generate([{:partial, "upcase", 1, 0, ""}])
     {fun, []} = Code.eval_quoted(quoted_fun)
-    assert fun.(%{context: "cheeseburgers", partials: %{upcase: &String.upcase/1}}) == "CHEESEBURGERS\n"
+    assert fun.(%{context: "cheeseburgers", partials: %{upcase: &String.upcase/1}}) == "CHEESEBURGERS"
   end
 
 end

--- a/test/fumanchu/generator_test.exs
+++ b/test/fumanchu/generator_test.exs
@@ -59,4 +59,11 @@ defmodule FuManchu.GeneratorTest do
 
     assert Generator.generate(ast) == {:error, error}
   end
+
+  test "generating a function partial" do
+    {:ok, quoted_fun} = Generator.generate([{:partial, "upcase", 1, 0, ""}])
+    {fun, []} = Code.eval_quoted(quoted_fun)
+    assert fun.(%{context: "cheeseburgers", partials: %{upcase: &String.upcase/1}}) == "CHEESEBURGERS\n"
+  end
+
 end


### PR DESCRIPTION
This allows us to inject our own non-mustachey templating, like a json partial. Here's an example:

```
iex(1)> FuManchu.render!("{{> json}}", %{do: %{a: %{little: "dance"}}}, %{json: &Poison.encode!(&1, pretty: true)})
"{\n  \"do\": {\n    \"a\": {\n      \"little\": \"dance\"\n    }\n  }\n}\n"
```
