### PR TITLE
Fixing compiler warning.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule FuManchu.Mixfile do
      elixir: "~> 1.3.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      description: "An (almost) spec-compliant Mustache parser written in Elixir"]
   end
 


### PR DESCRIPTION
`warning: variable "deps" does not exist and is being expanded to "deps()"`